### PR TITLE
fix: test failure for locale other than US

### DIFF
--- a/app/src/test/java/com/example/tiptime/TipCalculatorTests.kt
+++ b/app/src/test/java/com/example/tiptime/TipCalculatorTests.kt
@@ -17,6 +17,7 @@ package com.example.tiptime
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.text.NumberFormat
 
 class TipCalculatorTests {
 
@@ -24,7 +25,7 @@ class TipCalculatorTests {
     fun calculate_20_percent_tip_no_roundup() {
         val amount = 10.00
         val tipPercent = 20.00
-        val expectedTip = "$2.00"
+        val expectedTip = NumberFormat.getCurrencyInstance().format(2.00)
         val actualTip = calculateTip(amount = amount, tipPercent = tipPercent, false)
         assertEquals(expectedTip, actualTip)
     }


### PR DESCRIPTION
The variable expectedTip in calculate_20_percent_tip_no_roundup was hardcoded with a currency format with dollar($), which would fail for the different locales.
This is fixed by formatting the expectedTip according to locale


Fixes #3, #20