### PR TITLE
Fixed default tip percentage in tip calculation

### DIFF
--- a/app/src/main/java/com/example/tiptime/MainActivity.kt
+++ b/app/src/main/java/com/example/tiptime/MainActivity.kt
@@ -82,7 +82,11 @@ fun TipTimeLayout() {
 
     val amount = amountInput.toDoubleOrNull() ?: 0.0
     val tipPercent = tipInput.toDoubleOrNull() ?: 0.0
-    val tip = calculateTip(amount, tipPercent, roundUp)
+    val tip = if (tipPercent == 0.0) {
+        calculateTip(amount = amount, roundUp = roundUp)
+    } else {
+        calculateTip(amount, tipPercent, roundUp)
+    }
 
     Column(
         modifier = Modifier


### PR DESCRIPTION
This commit allows the tip calculation to work correctly when no tip percentage is provided by the user. Previously, if the user left the tip percentage field empty, the calculation would not work as expected.