### PR TITLE
Fix: Restrict tip percent between 0-100%

### DIFF
--- a/app/src/androidTest/java/com/example/tiptime/TipUITests.kt
+++ b/app/src/androidTest/java/com/example/tiptime/TipUITests.kt
@@ -1,0 +1,36 @@
+package com.example.tiptime
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
+import com.example.tiptime.ui.theme.TipTimeTheme
+import org.junit.Rule
+import org.junit.Test
+import java.text.NumberFormat
+
+class TipUITests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun calcalculateTip_1000PercentNoRoundUp_SolveError() {
+        composeTestRule.setContent {
+            TipTimeTheme {
+                TipTimeLayout()
+            }
+        }
+
+        composeTestRule.onNodeWithText("Bill Amount")
+            .performTextInput("100")
+
+        composeTestRule.onNodeWithText("Tip Percentage")
+            .performTextInput("1000")
+
+        val expectedTip = NumberFormat.getCurrencyInstance().format(100)
+        composeTestRule.onNodeWithText("Tip Amount: $expectedTip").assertExists(
+            "No node with this text was found."
+        )
+
+    }
+}

--- a/app/src/main/java/com/example/tiptime/MainActivity.kt
+++ b/app/src/main/java/com/example/tiptime/MainActivity.kt
@@ -180,7 +180,8 @@ fun RoundTheTipRow(
  * Example would be "$10.00".
  */
 private fun calculateTip(amount: Double, tipPercent: Double = 15.0, roundUp: Boolean): String {
-    var tip = tipPercent / 100 * amount
+    val isValidationPercent = tipPercent.coerceIn(0.0 , 100.0)
+    var tip = isValidationPercent / 100 * amount
     if (roundUp) {
         tip = kotlin.math.ceil(tip)
     }

--- a/app/src/test/java/com/example/tiptime/TipCalculatorTests.kt
+++ b/app/src/test/java/com/example/tiptime/TipCalculatorTests.kt
@@ -1,0 +1,39 @@
+package com.example.tiptime
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import java.text.NumberFormat
+
+
+class TipCalculatorTests {
+
+    @Test
+    fun calculateTip_20PercentNoRoundup() {
+
+        val amount = 10.00
+        val tipPercent = 20.00
+        val expectedAmount = NumberFormat.getCurrencyInstance().format(2)
+        val actualTip = calculateTip(amount = amount, tipPercent = tipPercent, roundUp = false)
+        assertEquals(expectedAmount, actualTip)
+
+    }
+
+    @Test
+    fun calculateTip_1000PercentNoRoundUp() {
+        val amount = 100.00
+        val tipPercent = 1000.00
+        val exceptedAmount = NumberFormat.getCurrencyInstance().format(100)
+        val actualtip = calculateTip(amount = amount, tipPercent = tipPercent, roundUp = false)
+        assertEquals(exceptedAmount, actualtip)
+    }
+
+}
+
+private fun calculateTip(amount: Double, tipPercent: Double = 15.0, roundUp: Boolean): String {
+    val isValidationPercent = tipPercent.coerceIn(0.0, 100.0)
+    var tip = isValidationPercent / 100 * amount
+    if (roundUp) {
+        tip = kotlin.math.ceil(tip)
+    }
+    return NumberFormat.getCurrencyInstance().format(tip)
+}


### PR DESCRIPTION
Description:
Implemented isValidTipPercent using coerceIn(0.0, 100.0) to ensure the tip percentage remains within a valid range (0 to 100).

Previously, an invalid tip percentage (e.g., negative values or values above 100) could result in incorrect tip calculations.

Adding this validation ensures that the function behaves predictably and avoids unexpected results.